### PR TITLE
Refactor docker workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!entrypoint.sh

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,38 @@
+name: Build and deploy container to GHCR
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tags: latest
+
+    - name: Build and push container
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data/
+gamefiles/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM ubuntu:22.04
 
 RUN dpkg --add-architecture i386 && \
+    apt-get update && \
     echo steam steam/question select "I AGREE" | debconf-set-selections && \
     echo steam steam/license note '' | debconf-set-selections && \
-    apt-get update && \
-    apt-get install -y wine64 steamcmd && \
-    apt-get install -y --reinstall winbind && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wine64 steamcmd && \
     apt-get clean autoclean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -13,15 +12,6 @@ RUN dpkg --add-architecture i386 && \
 ENV PATH="$PATH:/usr/games"
 
 WORKDIR /steamcmd
-
-RUN set -x \
-        && mkdir -p "/server" \
-        && steamcmd \
-                +@sSteamCmdForcePlatformType windows \
-                +force_install_dir /server \
-                +login anonymous \
-                +app_update 2857200 validate \
-                +quit
 
 COPY ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -3,14 +3,25 @@ For operating a dedicated server in Docker in order to use it under Linux.
 The container uses Wine to run the server under Linux. 
 
 ## Setup
-Setup and start via docker-compose with `docker-compose up -d --build`.
-
-In the docker-compose.yml config file, the environment variables `ServerPassword` and `SteamServerName` should be adjusted.
+1. Create a new empty directory in any location with enough storage space.
+2. Create a file named `docker-compose.yml` and copy the content of [`docker-compose.yml.example`](docker-compose.yml.example) into it.
+3. In the `docker-compose.yml` file, the environment variables `ServerPassword` and `SteamServerName` should be adjusted.
+4. Setup and start via docker-compose by running the command `docker-compose up -d`.
+    * This will run the server in the background and autostart it whenever the docker daemon starts. If you do not want this, remove `-d` from the command above.
+    * This will download the Dedicated Server binaries and game files to the `gamefiles` directory.
+    * Persistent save file data will be written to the `data` directory.
 
 ## Update
 There are two ways to update the game server:
+
 1. By setting the `AutoUpdate` environment variable to `true`. This checks for updates every time the container is started.
-2. By rebuilding the Docker image.
+2. By deleting the `gamefiles` directory while the server is turned off.
+
+### Updating the container
+Sometimes, changes to this container image are necessary. To apply these:
+
+1. Merge the content of `docker-compose.yml` with any changes made from [`docker-compose.yml.example`](docker-compose.yml.example).
+2. Run `docker-compose pull` to download an updated version of the container image.
 
 ## Configuration
 An example configuration for docker-compose can be found in the `docker-compose.yml` file.

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,11 +1,9 @@
 services:
   abiotic-server:
-    image: abiotic:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: "ghcr.io/Pleut/abiotic-factor-linux-docker:latest"
     restart: unless-stopped
     volumes:
+      - "./gamefiles:/server"
       - "./data:/server/AbioticFactor/Saved"
     environment:
       - MaxServerPlayers=6

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,8 @@ SteamServerName="${SteamServerName:-LinuxServer}"
 WorldSaveName="${WorldSaveName:-Cascade}"
 AdditionalArgs="${AdditionalArgs:-}"
 
-# Check for updates
-if [[ $AutoUpdate == "true" ]]; then
+# Check for updates/perform initial installation
+if [ ! -d "/server/AbioticFactor/Binaries/Win64" ] || [[ $AutoUpdate == "true" ]]; then
     steamcmd \
     +@sSteamCmdForcePlatformType windows \
     +force_install_dir /server \
@@ -26,7 +26,8 @@ if [[ $AutoUpdate == "true" ]]; then
     +quit
 fi
 
-cd /server/AbioticFactor/Binaries/Win64
+pushd /server/AbioticFactor/Binaries/Win64 > /dev/null
 wine AbioticFactorServer-Win64-Shipping.exe $SetUsePerfThreads$SetNoAsyncLoadingThread-MaxServerPlayers=$MaxServerPlayers \
     -PORT=$Port -QueryPort=$QueryPort -ServerPassword=$ServerPassword \
     -SteamServerName="$SteamServerName" -WorldSaveName="$WorldSaveName" -tcp $AdditionalArgs
+popd > /dev/null


### PR DESCRIPTION
This pull request changes quite a number of things. Primarily, GitHub Actions will build the container image and provide it for download on GHCR automatically, instead of having every user of this repository build it instead.

Additionally, cloning the repository is also no longer necessary, so this container can be used in a lot of other scenarios where that is not possible as well! Another upside is that compared to the current setup, any future game updates that trigger the auto update mechanism will actually be saved to disk compared to the standard behavior of docker-compose when docker-compose down is executed.