### PR TITLE
Handle state is 0x6 when updating server binaries

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,12 @@
+app_update() {
+    steamcmd \
+    +@sSteamCmdForcePlatformType windows \
+    +force_install_dir /server \
+    +login anonymous \
+    +app_update 2857200 validate \
+    +quit
+}
+
 SetUsePerfThreads="-useperfthreads "
 if [[ $UsePerfThreads == "false" ]]; then
     SetUsePerfThreads=""
@@ -18,12 +27,13 @@ AdditionalArgs="${AdditionalArgs:-}"
 
 # Check for updates/perform initial installation
 if [ ! -d "/server/AbioticFactor/Binaries/Win64" ] || [[ $AutoUpdate == "true" ]]; then
-    steamcmd \
-    +@sSteamCmdForcePlatformType windows \
-    +force_install_dir /server \
-    +login anonymous \
-    +app_update 2857200 validate \
-    +quit
+    app_update | tee /tmp/app_update.log
+    grep -q "state is 0x6" /tmp/app_update.log
+    if [ $? -eq 0 ]; then
+        echo "Update failed with 'state is 0x6', wiping server files and retrying (your saved games will be preserved)"
+        find /server/* -not -path "/server/AbioticFactor/Saved*" -not -path "/server/AbioticFactor" -delete
+        app_update
+    fi
 fi
 
 pushd /server/AbioticFactor/Binaries/Win64 > /dev/null


### PR DESCRIPTION
### Problem
When autoupdates are enabled, the update process can sometimes fail with a "state is 0x6" error. The workaround is to wipe out the server files and force a full redownload, but this requires manual intervention from server maintainers.

### Solution
Updated `entrypoint.sh` to detect any "state is 0x6" error when attempting server update. If the error is found then `find` is used to wipe the server files, then the update is retried to redownload a clean copy of the binaries. The saved game directory is excluded from the delete operation.

### Testing Done
With the problem `gamefiles` directory from https://github.com/Pleut/abiotic-factor-linux-docker/issues/22, confirmed that the auto-update process correctly detected the 0x6 error, wiped server files and redownloaded:
```
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/root/Steam/logs/stderr.txt'
Logging directory: '/root/Steam/logs'
[  0%] Checking for available updates...
[----] Verifying installation...
UpdateUI: skip show logo
Steam Console Client (c) Valve Corporation - version 1759461699
-- type 'quit' to exit --
Loading Steam API...OK
"@sSteamCmdForcePlatformType" = "windows"

Connecting anonymously to Steam Public...OK
Waiting for client config...OK
Waiting for user info...OK
Error! App '2857200' state is 0x6 after update job.
Unloading Steam API...OK
Update failed with 'state is 0x6', wiping server files and retrying (your saved games will be preserved)
ln: failed to create symbolic link '/root/.steam/root': No such file or directory
ln: failed to create symbolic link '/root/.steam/steam': No such file or directory
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/root/Steam/logs/stderr.txt'
Logging directory: '/root/Steam/logs'
[  0%] Checking for available updates...
[----] Verifying installation...
UpdateUI: skip show logo
Steam Console Client (c) Valve Corporation - version 1759461699
-- type 'quit' to exit --
Loading Steam API...OK
"@sSteamCmdForcePlatformType" = "windows"

Connecting anonymously to Steam Public...OK
Waiting for client config...OK
Waiting for user info...OK
 Update state (0x61) downloading, progress: 0.11 (3146865 / 2873066191)
 Update state (0x61) downloading, progress: 1.71 (49027467 / 2873066191)
 Update state (0x61) downloading, progress: 13.33 (383076747 / 2873066191)
 Update state (0x61) downloading, progress: 25.74 (739592587 / 2873066191)
 Update state (0x61) downloading, progress: 39.50 (1134913931 / 2873066191)
 Update state (0x61) downloading, progress: 52.99 (1522563467 / 2873066191)
 Update state (0x61) downloading, progress: 64.21 (1844811845 / 2873066191)
 Update state (0x61) downloading, progress: 76.30 (2192222720 / 2873066191)
 Update state (0x61) downloading, progress: 89.07 (2559015911 / 2873066191)
 Update state (0x61) downloading, progress: 97.90 (2812672221 / 2873066191)
 Update state (0x81) verifying update, progress: 4.20 (120635787 / 2873066191)
 Update state (0x81) verifying update, progress: 14.10 (405096843 / 2873066191)
 Update state (0x81) verifying update, progress: 21.55 (619006347 / 2873066191)
 Update state (0x81) verifying update, progress: 30.09 (864373131 / 2873066191)
 Update state (0x81) verifying update, progress: 38.26 (1099262347 / 2873066191)
 Update state (0x81) verifying update, progress: 48.59 (1396009355 / 2873066191)
 Update state (0x81) verifying update, progress: 61.50 (1766941704 / 2873066191)
IPC function call IClientAppManager::GetUpdateInfo took too long: 123 msec
Success! App '2857200' fully installed.
```

Manually confirmed that game save state was not affected by the auto-update.